### PR TITLE
Fix PKCS#11 attribute retrieval

### DIFF
--- a/pkcs11_definitions.py
+++ b/pkcs11_definitions.py
@@ -15,7 +15,7 @@ def define_pkcs11_functions(pkcs11):
     pkcs11.C_GetSlotList.argtypes = [ctypes.c_bool, ctypes.POINTER(ctypes.c_ulong), ctypes.POINTER(ctypes.c_ulong)]
     pkcs11.C_GetSlotList.restype = ctypes.c_ulong
 
-    # C_GetSlotInfo
+    # C_GetTokenInfo
     pkcs11.C_GetTokenInfo.argtypes = [ctypes.c_ulong, ctypes.POINTER(CK_TOKEN_INFO)]
     pkcs11.C_GetTokenInfo.restype = ctypes.c_ulong
 
@@ -40,5 +40,10 @@ def define_pkcs11_functions(pkcs11):
     pkcs11.C_FindObjectsFinal.restype = ctypes.c_ulong
 
     # C_GetAttributeValue
-    pkcs11.C_GetAttributeValue.argtypes = [ctypes.c_ulong, ctypes.POINTER(CK_ATTRIBUTE), ctypes.c_ulong]  # CK_ATTRIBUTE
+    pkcs11.C_GetAttributeValue.argtypes = [
+        ctypes.c_ulong,  # CK_SESSION_HANDLE
+        ctypes.c_ulong,  # CK_OBJECT_HANDLE
+        ctypes.POINTER(CK_ATTRIBUTE),  # CK_ATTRIBUTE_PTR
+        ctypes.c_ulong,  # ulCount
+    ]
     pkcs11.C_GetAttributeValue.restype = ctypes.c_ulong


### PR DESCRIPTION
## Summary
- fix the argument list for `C_GetAttributeValue`
- correct comment for `C_GetTokenInfo`

## Testing
- `python -m py_compile pkcs11_definitions.py`
- `python -m py_compile commands.py main.py pkcs11.py pkcs11_structs.py`
- `python main.py --help | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684ac803959c8329be2f204a9899b6eb