### PR TITLE
Improve factory reset pin handling

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -28,10 +28,14 @@ def factory_reset(pkcs11, slot_id, pin, label):
     define_pkcs11_functions(pkcs11)  # Настраиваем argtypes и restype
 
     slot_id = int(slot_id)
-    pin = pin.encode('utf-8')
+    pin_bytes = pin.encode('utf-8') if pin else None
     label = label.encode('utf-8')
 
-    rv = pkcs11.C_EX_InitToken(slot_id, pin, label)
+    if pin_bytes is None:
+        print('Необходимо указать PIN-код для фабричного сброса.', file=sys.stderr)
+        return
+
+    rv = pkcs11.C_EX_InitToken(slot_id, pin_bytes, label)
     if rv != 0:
         print(f'C_EX_InitToken вернула ошибку: 0x{rv:08X}')
     else:


### PR DESCRIPTION
## Summary
- check for missing PIN in `factory_reset`
- encode the PIN only when provided
- fail early when no PIN is supplied

## Testing
- `python -m py_compile commands.py pkcs11.py pkcs11_definitions.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684ace4839c083298a1d05eab105c76c