### PR TITLE
Fix types for PKCS#11 version fields

### DIFF
--- a/pkcs11_structs.py
+++ b/pkcs11_structs.py
@@ -34,8 +34,8 @@ class CK_SLOT_INFO(ctypes.Structure):
         ('slotDescription', ctypes.c_char * 64),
         ('manufacturerID', ctypes.c_char * 32),
         ('flags', ctypes.c_ulong),
-        ('hardwareVersion', CK_INFO),
-        ('firmwareVersion', CK_INFO),
+        ('hardwareVersion', CK_VERSION),
+        ('firmwareVersion', CK_VERSION),
     ]
 
 class CK_TOKEN_INFO(ctypes.Structure):
@@ -55,8 +55,8 @@ class CK_TOKEN_INFO(ctypes.Structure):
         ('ulFreePublicMemory', ctypes.c_ulong),
         ('ulTotalPrivateMemory', ctypes.c_ulong),
         ('ulFreePrivateMemory', ctypes.c_ulong),
-        ('hardwareVersion', CK_INFO),
-        ('firmwareVersion', CK_INFO),
+        ('hardwareVersion', CK_VERSION),
+        ('firmwareVersion', CK_VERSION),
         ('utcTime', ctypes.c_char * 16),
     ]
 


### PR DESCRIPTION
## Summary
- use `CK_VERSION` for `hardwareVersion` and `firmwareVersion` fields

## Testing
- `python -m py_compile $(ls *.py)`

------
https://chatgpt.com/codex/tasks/task_e_684ace3be37c832993c8e15fe976311b