### PR TITLE
Fix struct packing for Windows

### DIFF
--- a/pkcs11_structs.py
+++ b/pkcs11_structs.py
@@ -18,9 +18,11 @@ CKF_RW_SESSION = 1 << 2  # 0x00000004
 CK_VOID_PTR = ctypes.c_void_p
 
 class CK_VERSION(ctypes.Structure):
+    _pack_ = 1
     _fields_ = [('major', ctypes.c_ubyte), ('minor', ctypes.c_ubyte)]
 
 class CK_INFO(ctypes.Structure):
+    _pack_ = 1
     _fields_ = [
         ('cryptokiVersion', CK_VERSION),
         ('manufacturerID', ctypes.c_char * 32),
@@ -30,6 +32,7 @@ class CK_INFO(ctypes.Structure):
     ]
 
 class CK_SLOT_INFO(ctypes.Structure):
+    _pack_ = 1
     _fields_ = [
         ('slotDescription', ctypes.c_char * 64),
         ('manufacturerID', ctypes.c_char * 32),
@@ -39,6 +42,7 @@ class CK_SLOT_INFO(ctypes.Structure):
     ]
 
 class CK_TOKEN_INFO(ctypes.Structure):
+    _pack_ = 1
     _fields_ = [
         ('label', ctypes.c_char * 32),
         ('manufacturerID', ctypes.c_char * 32),
@@ -61,6 +65,7 @@ class CK_TOKEN_INFO(ctypes.Structure):
     ]
 
 class CK_ATTRIBUTE(ctypes.Structure):
+    _pack_ = 1
     _fields_ = [
         ('type', ctypes.c_ulong),
         ('pValue', ctypes.c_void_p),


### PR DESCRIPTION
## Summary
- pack PKCS#11 structures so that ctypes layouts match the C headers

## Testing
- `python -m py_compile *.py`
- `pyinstaller --onefile main.py` *(fails: built but no token so commands return errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864015336a483298d9aa6d410aeb581