### PR TITLE
Fix PKCS11 constants and tests

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,7 +1,18 @@
 import ctypes
 import sys
 from pkcs11 import pkcs11_command
-from pkcs11_structs import CK_INFO, CK_SLOT_INFO, CK_TOKEN_INFO, CK_ATTRIBUTE, CKA_CLASS, CKO_PUBLIC_KEY, CKF_SERIAL_SESSION, CKF_RW_SESSION
+from pkcs11_structs import (
+    CK_INFO,
+    CK_TOKEN_INFO,
+    CK_ATTRIBUTE,
+    CKA_CLASS,
+    CKA_LABEL,
+    CKA_ID,
+    CKA_VALUE,
+    CKO_PUBLIC_KEY,
+    CKF_SERIAL_SESSION,
+    CKF_RW_SESSION,
+)
 from pkcs11_definitions import define_pkcs11_functions
 
 @pkcs11_command
@@ -120,17 +131,13 @@ def list_objects(pkcs11, slot_id, pin):
             pkcs11.C_CloseSession(session)
             return
 
-    # 1) создаём переменную и сохраняем её в локальной области видимости
-    val = ctypes.c_ulong(CKO_PUBLIC_KEY)
-
-    # 2) формируем структуру CK_ATTRIBUTE, приводя указатель к void*
+    # Готовим шаблон поиска: объекты класса "публичный ключ"
+    class_val = ctypes.c_ulong(CKO_PUBLIC_KEY)
     attr = CK_ATTRIBUTE()
     attr.type = CKA_CLASS
-    attr.pValue = ctypes.cast(ctypes.pointer(val), ctypes.c_void_p)
-    attr.ulValueLen = ctypes.sizeof(val)
-    
+    attr.pValue = ctypes.cast(ctypes.pointer(class_val), ctypes.c_void_p)
+    attr.ulValueLen = ctypes.sizeof(class_val)
 
-    # 3) создаём массив из одного атрибута
     template = (CK_ATTRIBUTE * 1)(attr)
 
     # 4) инициализируем поиск
@@ -152,19 +159,19 @@ def list_objects(pkcs11, slot_id, pin):
 
         # Получаем атрибуты объекта
         attributes = [
-            {"type": 0x00000082, "name": "CKA_LABEL"},  # Метка
-            {"type": 0x00000083, "name": "CKA_ID"},     # Идентификатор
-            {"type": 0x00000086, "name": "CKA_VALUE"},  # ключа
+            (CKA_LABEL, "CKA_LABEL"),  # Метка
+            (CKA_ID, "CKA_ID"),        # Идентификатор
+            (CKA_VALUE, "CKA_VALUE"),  # Значение ключа
         ]
 
         print(f'  ID ключа: {obj.value}')
-        for attr in attributes:
-            attr_template = CK_ATTRIBUTE(type=attr["type"], pValue=None, ulValueLen=0)
+        for attr_type, attr_name in attributes:
+            attr_template = CK_ATTRIBUTE(type=attr_type, pValue=None, ulValueLen=0)
 
             # Сначала получаем размер атрибута
             rv = pkcs11.C_GetAttributeValue(session, obj, ctypes.byref(attr_template), 1)
             if rv != 0:
-                print(f'    Ошибка получения {attr["name"]}: 0x{rv:08X}')
+                print(f'    Ошибка получения {attr_name}: 0x{rv:08X}')
                 continue
 
             # Если размер атрибута больше 0, получаем его значение
@@ -173,25 +180,25 @@ def list_objects(pkcs11, slot_id, pin):
                 attr_template.pValue = ctypes.cast(value, ctypes.c_void_p)
                 rv = pkcs11.C_GetAttributeValue(session, obj, ctypes.byref(attr_template), 1)
                 if rv == 0:
-                    if attr["name"] == "CKA_VALUE":
+                    if attr_name == "CKA_VALUE":
                         # Ограничиваем вывод первых 64 символов
                         value_str = bytes(value).decode('utf-8', errors='ignore').replace('\x00', ' ')
                         truncated_value = value_str[:64]
                         skipped_chars = len(value_str) - 64 if len(value_str) > 64 else 0
-                        print(f'    {attr["name"]}: {truncated_value} (пропущено {skipped_chars} символов)')
+                        print(f'    {attr_name}: {truncated_value} (пропущено {skipped_chars} символов)')
                     else:
                         # Проверяем, содержит ли значение непечатные символы
                         try:
                             decoded_value = bytes(value).decode('utf-8')
                             if all(32 <= ord(c) <= 126 for c in decoded_value):
-                                print(f'    {attr["name"]} (TEXT): {decoded_value}')
+                                print(f'    {attr_name} (TEXT): {decoded_value}')
                             else:
                                 raise ValueError
                         except ValueError:
                             hex_value = " ".join(f"{b:02X}" for b in value)
-                            print(f'    {attr["name"]} (HEX): {hex_value}')
+                            print(f'    {attr_name} (HEX): {hex_value}')
                 else:
-                    print(f'    Ошибка получения значения {attr["name"]}: 0x{rv:08X}')
+                    print(f'    Ошибка получения значения {attr_name}: 0x{rv:08X}')
 
     # Завершаем поиск объектов
     pkcs11.C_FindObjectsFinal(session)

--- a/pkcs11_structs.py
+++ b/pkcs11_structs.py
@@ -2,14 +2,20 @@ import ctypes
 import sys
 
 # Константы
+# Значения классов объектов согласно спецификации PKCS#11
 CKA_CLASS = 0x00000000  # Тип объекта
-CKO_CERTIFICATE = 0x00000001  # Объект сертификата
-CKO_PRIVATE_KEY = 0x00000002  # Объект закрытого ключа
-CKO_PUBLIC_KEY = 0x00000003  # Объект открытого ключа
-CKO_SECRET_KEY = 0x00000004  # Объект секретного ключа
-CKO_DATA = 0x00000005  # Объект данных
-CKO_DOMAIN_PARAMETERS = 0x00000006  # Объект параметров домена
-CKO_HW_FEATURE = 0x00000007  # Объект аппаратного обеспечения
+CKO_DATA = 0x00000000
+CKO_CERTIFICATE = 0x00000001
+CKO_PUBLIC_KEY = 0x00000002
+CKO_PRIVATE_KEY = 0x00000003
+CKO_SECRET_KEY = 0x00000004
+CKO_HW_FEATURE = 0x00000005
+CKO_DOMAIN_PARAMETERS = 0x00000006
+
+# Наиболее часто используемые атрибуты
+CKA_LABEL = 0x00000003
+CKA_VALUE = 0x00000011
+CKA_ID = 0x00000102
 
 CKF_SERIAL_SESSION = 1 << 1  # 0x00000002
 CKF_RW_SESSION = 1 << 2  # 0x00000004
@@ -70,8 +76,7 @@ class CK_TOKEN_INFO(ctypes.Structure):
     ]
 
 class CK_ATTRIBUTE(ctypes.Structure):
-    if sys.platform.startswith("win"):
-        _pack_ = 1
+    _pack_ = 1
     _fields_ = [
         ('type', ctypes.c_ulong),
         ('pValue', ctypes.c_void_p),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,53 @@
+import ctypes
+from types import SimpleNamespace
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import commands
+import pkcs11
+import pkcs11_structs as structs
+
+
+def test_list_objects_search_template(monkeypatch):
+    pkcs11_mock = SimpleNamespace()
+
+    def open_session(slot, flags, app, notify, session_ptr):
+        session_ptr._obj.value = 123
+        return 0
+    pkcs11_mock.C_OpenSession = open_session
+
+    pkcs11_mock.C_Login = lambda *args: 0
+    captured = {}
+
+    def find_objects_init(session_handle, template_ptr, count):
+        arr_type = structs.CK_ATTRIBUTE * count
+        arr = ctypes.cast(template_ptr, ctypes.POINTER(arr_type)).contents
+        attr = arr[0]
+        captured['session'] = session_handle
+        captured['type'] = attr.type
+        val_ptr = ctypes.cast(attr.pValue, ctypes.POINTER(ctypes.c_ulong))
+        captured['value'] = val_ptr.contents.value
+        captured['len'] = attr.ulValueLen
+        return 0
+    pkcs11_mock.C_FindObjectsInit = find_objects_init
+
+    def find_objects(session, obj_ptr, max_obj, count_ptr):
+        count_ptr._obj.value = 0
+        return 0
+    pkcs11_mock.C_FindObjects = find_objects
+
+    pkcs11_mock.C_FindObjectsFinal = lambda session: 0
+    pkcs11_mock.C_CloseSession = lambda session: 0
+    pkcs11_mock.C_GetAttributeValue = lambda *args: 0
+
+    monkeypatch.setattr(pkcs11, "load_pkcs11_lib", lambda: pkcs11_mock)
+    monkeypatch.setattr(pkcs11, "initialize_library", lambda x: None)
+    monkeypatch.setattr(pkcs11, "finalize_library", lambda x: None)
+    monkeypatch.setattr(commands, "define_pkcs11_functions", lambda x: None)
+
+    commands.list_objects(slot_id=1, pin="0000")
+
+    assert captured['session'] == 123
+    assert captured['type'] == structs.CKA_CLASS
+    assert captured['value'] == structs.CKO_PUBLIC_KEY
+    assert captured['len'] == ctypes.sizeof(ctypes.c_ulong)


### PR DESCRIPTION
## Summary
- correct PKCS#11 object class values and add more attribute constants
- pack `CK_ATTRIBUTE` on all platforms
- refactor `list_objects` to use new constants
- drop unused struct import
- add a smoke test for `list_objects`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686508f82eb48329b21d9475666e7b14