### PR TITLE
Print sequential key numbers

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -10,6 +10,7 @@ from pkcs11_structs import (
     CKA_ID,
     CKA_VALUE,
     CKO_PUBLIC_KEY,
+    CKO_PRIVATE_KEY,
     CKF_SERIAL_SESSION,
     CKF_RW_SESSION,
     CKR_TOKEN_NOT_PRESENT,
@@ -155,10 +156,9 @@ def list_wallets(pkcs11):
 
 @pkcs11_command
 def list_objects(pkcs11, slot_id, pin):
-    """Ищет ключи в кошельке и выводит их атрибуты."""
-    define_pkcs11_functions(pkcs11)  # Настраиваем argtypes и restype
+    """Выводит список ключей. Если PIN не задан, показываются только публичные ключи."""
+    define_pkcs11_functions(pkcs11)
 
-    # Открываем сессию
     session = ctypes.c_ulong()
     rv = pkcs11.C_OpenSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, None, None, ctypes.byref(session))
     if rv == CKR_TOKEN_NOT_PRESENT:
@@ -168,72 +168,94 @@ def list_objects(pkcs11, slot_id, pin):
         print(f'C_OpenSession вернула ошибку: 0x{rv:08X}')
         return
 
-    # Выполняем логин
+    logged_in = False
     if pin:
         rv = pkcs11.C_Login(session, 1, pin.encode('utf-8'), len(pin))
         if rv != 0:
             print(f'C_Login вернула ошибку: 0x{rv:08X}')
             pkcs11.C_CloseSession(session)
             return
+        logged_in = True
+    else:
+        print('Закрытые ключи не отображаются без ввода PIN-кода')
 
-    # Готовим шаблон поиска: объекты класса "публичный ключ"
-    class_val = ctypes.c_ulong(CKO_PUBLIC_KEY)
-    attr = CK_ATTRIBUTE()
-    attr.type = CKA_CLASS
-    attr.pValue = ctypes.cast(ctypes.pointer(class_val), ctypes.c_void_p)
-    attr.ulValueLen = ctypes.sizeof(class_val)
+    def search_objects(obj_class):
+        class_val = ctypes.c_ulong(obj_class)
+        attr = CK_ATTRIBUTE()
+        attr.type = CKA_CLASS
+        attr.pValue = ctypes.cast(ctypes.pointer(class_val), ctypes.c_void_p)
+        attr.ulValueLen = ctypes.sizeof(class_val)
+        template = (CK_ATTRIBUTE * 1)(attr)
 
-    template = (CK_ATTRIBUTE * 1)(attr)
+        rv = pkcs11.C_FindObjectsInit(session.value, template, 1)
+        if rv != 0:
+            print(f'C_FindObjectsInit вернула ошибку: 0x{rv:08X}')
+            return []
 
-    # 4) инициализируем поиск
- 
-    rv = pkcs11.C_FindObjectsInit(session.value, template, len(template))
-    if rv != 0:
-        print(f'C_FindObjectsInit вернула ошибку: 0x{rv:08X}')
-        pkcs11.C_CloseSession(session)
-        return
+        handles = []
+        obj = ctypes.c_ulong()
+        count = ctypes.c_ulong()
+        while True:
+            rv = pkcs11.C_FindObjects(session, ctypes.byref(obj), 1, ctypes.byref(count))
+            if rv != 0 or count.value == 0:
+                break
+            handles.append(obj.value)
+        pkcs11.C_FindObjectsFinal(session)
+        return handles
 
-    # Ищем объекты
-    print('Список ключей в кошельке:')
-    obj = ctypes.c_ulong()
-    count = ctypes.c_ulong()
-    while True:
-        rv = pkcs11.C_FindObjects(session, ctypes.byref(obj), 1, ctypes.byref(count))
-        if rv != 0 or count.value == 0:
-            break
-
-        # Получаем атрибуты объекта
-        attributes = [
-            (CKA_LABEL, "CKA_LABEL"),  # Метка
-            (CKA_ID, "CKA_ID"),        # Идентификатор
-            (CKA_VALUE, "CKA_VALUE"),  # Значение ключа
-        ]
-
-        print(f'  ID ключа: {obj.value}')
-        for attr_type, attr_name in attributes:
+    def get_attributes(handle):
+        attrs = {}
+        for attr_type, attr_name in [
+            (CKA_LABEL, 'CKA_LABEL'),
+            (CKA_ID, 'CKA_ID'),
+            (CKA_VALUE, 'CKA_VALUE'),
+        ]:
             attr_template = CK_ATTRIBUTE(type=attr_type, pValue=None, ulValueLen=0)
-
-            # Сначала получаем размер атрибута
-            rv = pkcs11.C_GetAttributeValue(session, obj, ctypes.byref(attr_template), 1)
-            if rv != 0:
-                print(f'    Ошибка получения {attr_name}: 0x{rv:08X}')
+            rv = pkcs11.C_GetAttributeValue(session, ctypes.c_ulong(handle), ctypes.byref(attr_template), 1)
+            if rv != 0 or attr_template.ulValueLen == 0:
                 continue
+            buf = (ctypes.c_ubyte * attr_template.ulValueLen)()
+            attr_template.pValue = ctypes.cast(buf, ctypes.c_void_p)
+            rv = pkcs11.C_GetAttributeValue(session, ctypes.c_ulong(handle), ctypes.byref(attr_template), 1)
+            if rv == 0:
+                attrs[attr_name] = bytes(buf)
+        return attrs
 
-            if attr_template.ulValueLen > 0:
-                buf = (ctypes.c_ubyte * attr_template.ulValueLen)()
-                attr_template.pValue = ctypes.cast(buf, ctypes.c_void_p)
-                rv = pkcs11.C_GetAttributeValue(session, obj, ctypes.byref(attr_template), 1)
-                if rv == 0:
-                    raw = bytes(buf)
+    objects = {}
+    for h in search_objects(CKO_PUBLIC_KEY):
+        attrs = get_attributes(h)
+        objects.setdefault(attrs.get('CKA_ID'), {})['public'] = (h, attrs)
+
+    if logged_in:
+        for h in search_objects(CKO_PRIVATE_KEY):
+            attrs = get_attributes(h)
+            objects.setdefault(attrs.get('CKA_ID'), {})['private'] = (h, attrs)
+
+    print('Список ключей в кошельке:')
+    index = 1
+    for key_id in sorted(objects.keys(), key=lambda x: x or b''):
+        pair = objects[key_id]
+        if 'public' in pair:
+            h, attrs = pair['public']
+            print(f'  Ключ #{index} (публичный):')
+            index += 1
+            for name in ['CKA_LABEL', 'CKA_ID', 'CKA_VALUE']:
+                if name in attrs:
+                    raw = attrs[name]
                     hex_repr = format_attribute_value(raw, "hex")
                     text_repr = format_attribute_value(raw, "text")
-                    print(f'    {attr_name} (HEX): {hex_repr}')
-                    print(f'    {attr_name} (TEXT): {text_repr}')
-                else:
-                    print(f'    Ошибка получения значения {attr_name}: 0x{rv:08X}')
+                    print(f'    {name} (HEX): {hex_repr}')
+                    print(f'    {name} (TEXT): {text_repr}')
+        if 'private' in pair:
+            h, attrs = pair['private']
+            print(f'  Ключ #{index} (закрытый):')
+            index += 1
+            for name in ['CKA_LABEL', 'CKA_ID', 'CKA_VALUE']:
+                if name in attrs:
+                    raw = attrs[name]
+                    hex_repr = format_attribute_value(raw, "hex")
+                    text_repr = format_attribute_value(raw, "text")
+                    print(f'    {name} (HEX): {hex_repr}')
+                    print(f'    {name} (TEXT): {text_repr}')
 
-    # Завершаем поиск объектов
-    pkcs11.C_FindObjectsFinal(session)
-
-    # Закрываем сессию
     pkcs11.C_CloseSession(session)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,7 +8,7 @@ import pkcs11
 import pkcs11_structs as structs
 
 
-def test_list_objects_search_template(monkeypatch):
+def test_list_objects_public_only_no_pin(monkeypatch, capsys):
     pkcs11_mock = SimpleNamespace()
 
     def open_session(slot, flags, app, notify, session_ptr):
@@ -16,18 +16,20 @@ def test_list_objects_search_template(monkeypatch):
         return 0
     pkcs11_mock.C_OpenSession = open_session
 
-    pkcs11_mock.C_Login = lambda *args: 0
-    captured = {}
+    login_called = []
+    def login(*args):
+        login_called.append(True)
+        return 0
+    pkcs11_mock.C_Login = login
+
+    captured = []
 
     def find_objects_init(session_handle, template_ptr, count):
         arr_type = structs.CK_ATTRIBUTE * count
         arr = ctypes.cast(template_ptr, ctypes.POINTER(arr_type)).contents
         attr = arr[0]
-        captured['session'] = session_handle
-        captured['type'] = attr.type
         val_ptr = ctypes.cast(attr.pValue, ctypes.POINTER(ctypes.c_ulong))
-        captured['value'] = val_ptr.contents.value
-        captured['len'] = attr.ulValueLen
+        captured.append(val_ptr.contents.value)
         return 0
     pkcs11_mock.C_FindObjectsInit = find_objects_init
 
@@ -45,12 +47,56 @@ def test_list_objects_search_template(monkeypatch):
     monkeypatch.setattr(pkcs11, "finalize_library", lambda x: None)
     monkeypatch.setattr(commands, "define_pkcs11_functions", lambda x: None)
 
+    commands.list_objects(slot_id=1, pin=None)
+
+    out = capsys.readouterr().out
+    assert "Закрытые ключи не отображаются" in out
+    assert login_called == []
+    assert captured == [structs.CKO_PUBLIC_KEY]
+
+
+def test_list_objects_with_pin_search_templates(monkeypatch):
+    pkcs11_mock = SimpleNamespace()
+
+    def open_session(slot, flags, app, notify, session_ptr):
+        session_ptr._obj.value = 123
+        return 0
+    pkcs11_mock.C_OpenSession = open_session
+
+    pkcs11_mock.C_FindObjectsFinal = lambda session: 0
+    pkcs11_mock.C_CloseSession = lambda session: 0
+    pkcs11_mock.C_GetAttributeValue = lambda *args: 0
+
+    calls = []
+    def find_objects_init(session_handle, template_ptr, count):
+        arr_type = structs.CK_ATTRIBUTE * count
+        arr = ctypes.cast(template_ptr, ctypes.POINTER(arr_type)).contents
+        attr = arr[0]
+        val_ptr = ctypes.cast(attr.pValue, ctypes.POINTER(ctypes.c_ulong))
+        calls.append(val_ptr.contents.value)
+        return 0
+    pkcs11_mock.C_FindObjectsInit = find_objects_init
+
+    def find_objects(session, obj_ptr, max_obj, count_ptr):
+        count_ptr._obj.value = 0
+        return 0
+    pkcs11_mock.C_FindObjects = find_objects
+
+    login_called = []
+    def login(*args):
+        login_called.append(True)
+        return 0
+    pkcs11_mock.C_Login = login
+
+    monkeypatch.setattr(pkcs11, "load_pkcs11_lib", lambda: pkcs11_mock)
+    monkeypatch.setattr(pkcs11, "initialize_library", lambda x: None)
+    monkeypatch.setattr(pkcs11, "finalize_library", lambda x: None)
+    monkeypatch.setattr(commands, "define_pkcs11_functions", lambda x: None)
+
     commands.list_objects(slot_id=1, pin="0000")
 
-    assert captured['session'] == 123
-    assert captured['type'] == structs.CKA_CLASS
-    assert captured['value'] == structs.CKO_PUBLIC_KEY
-    assert captured['len'] == ctypes.sizeof(ctypes.c_ulong)
+    assert len(login_called) == 1
+    assert set(calls) == {structs.CKO_PUBLIC_KEY, structs.CKO_PRIVATE_KEY}
 
 
 def test_list_wallets_no_wallet(monkeypatch, capsys):
@@ -101,6 +147,62 @@ def test_list_objects_no_wallet(monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "Нет подключенного кошелька" in captured.out
+
+
+def test_list_objects_numbering(monkeypatch, capsys):
+    """Objects are numbered sequentially when printed."""
+    pkcs11_mock = SimpleNamespace()
+
+    def open_session(slot, flags, app, notify, session_ptr):
+        session_ptr._obj.value = 321
+        return 0
+
+    pkcs11_mock.C_OpenSession = open_session
+    pkcs11_mock.C_Login = lambda *args: 0
+
+    search_class = None
+    def find_objects_init(session, template_ptr, count):
+        arr_type = structs.CK_ATTRIBUTE * count
+        attr = ctypes.cast(template_ptr, ctypes.POINTER(arr_type)).contents[0]
+        val_ptr = ctypes.cast(attr.pValue, ctypes.POINTER(ctypes.c_ulong))
+        nonlocal search_class
+        search_class = val_ptr.contents.value
+        return 0
+
+    pkcs11_mock.C_FindObjectsInit = find_objects_init
+
+    objects_pub = [100]
+    objects_priv = [200]
+
+    def find_objects(session, obj_ptr, max_obj, count_ptr):
+        lst = objects_pub if search_class == structs.CKO_PUBLIC_KEY else objects_priv
+        if lst:
+            obj_ptr._obj.value = lst.pop(0)
+            count_ptr._obj.value = 1
+        else:
+            count_ptr._obj.value = 0
+        return 0
+
+    pkcs11_mock.C_FindObjects = find_objects
+    pkcs11_mock.C_FindObjectsFinal = lambda *args: 0
+    pkcs11_mock.C_CloseSession = lambda *args: 0
+
+    def get_attr(session, obj, template_ptr, count):
+        template_ptr._obj.ulValueLen = 0
+        return 0
+
+    pkcs11_mock.C_GetAttributeValue = get_attr
+
+    monkeypatch.setattr(pkcs11, "load_pkcs11_lib", lambda: pkcs11_mock)
+    monkeypatch.setattr(pkcs11, "initialize_library", lambda x: None)
+    monkeypatch.setattr(pkcs11, "finalize_library", lambda x: None)
+    monkeypatch.setattr(commands, "define_pkcs11_functions", lambda x: None)
+
+    commands.list_objects(slot_id=1, pin="0000")
+
+    captured = capsys.readouterr()
+    assert "Ключ #1" in captured.out
+    assert "Ключ #2" in captured.out
 
 
 def test_format_attribute_value_text():


### PR DESCRIPTION
## Summary
- merge latest changes from main
- print keys with sequential numbers in `list_objects`
- update numbering test for new key listing implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68664e85439c83298eb88588008ddc24