### PR TITLE
Fix display of public key labels

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -263,8 +263,10 @@ def list_objects(pkcs11, slot_id, pin):
             h, attrs = pair['public']
             print('    Публичный ключ')
             for name in ['CKA_LABEL', 'CKA_ID', 'CKA_VALUE']:
-                if name in attrs:
-                    raw = attrs[name]
+                raw = attrs.get(name)
+                if raw is None and name == 'CKA_LABEL' and 'private' in pair:
+                    raw = pair['private'][1].get(name)
+                if raw is not None:
                     hex_repr = format_attribute_value(raw, "hex")
                     text_repr = format_attribute_value(raw, "text")
                     print(f'      {name} (HEX): {hex_repr}')


### PR DESCRIPTION
## Summary
- show `CKA_LABEL` for public keys when label exists only on the private key
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686900418dd8832987e8c7649cddcb35