### PR TITLE
Add key pair generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # wallet-tool
-example app to control the wallet
+Example app to control the wallet. Supported commands include listing slots,
+resetting the token and generating key pairs via PKCS#11.
+
+```
+python main.py --generate-key ed25519 --pin 0000
+```

--- a/main.py
+++ b/main.py
@@ -1,6 +1,13 @@
 import argparse
 import sys
-from commands import library_info, factory_reset, list_slots, list_wallets, list_objects
+from commands import (
+    library_info,
+    factory_reset,
+    list_slots,
+    list_wallets,
+    list_objects,
+    generate_key_pair,
+)
 
 # Для Windows: переключаем потоки в UTF-8, чтобы не падать на кириллице
 if sys.platform.startswith("win") and hasattr(sys.stdout, "reconfigure"):
@@ -23,6 +30,8 @@ def main():
                         help='Метка для фабричного сброса (по умолчанию пустая строка)')
     parser.add_argument('--list-objects', action='store_true',
                         help='Показать список объектов в кошельке')
+    parser.add_argument('--generate-key', choices=['secp256', 'ed25519', 'gost', 'rsa1024', 'rsa2048'],
+                        help='Сгенерировать ключевую пару указанного типа')
     parser.add_argument('--slot-id', type=int, default=0,
                         help='Идентификатор слота для выполнения команды (по умолчанию 0)')
     parser.add_argument('--pin', type=str, default=None,
@@ -40,6 +49,8 @@ def main():
         factory_reset(args.slot_id, args.pin, args.label)
     elif args.list_objects:
         list_objects(args.slot_id, args.pin)
+    elif args.generate_key:
+        generate_key_pair(args.slot_id, args.pin, args.generate_key)
     else:
         parser.print_help()
 

--- a/pkcs11_definitions.py
+++ b/pkcs11_definitions.py
@@ -47,3 +47,15 @@ def define_pkcs11_functions(pkcs11):
         ctypes.c_ulong,  # ulCount
     ]
     pkcs11.C_GetAttributeValue.restype = ctypes.c_ulong
+
+    # C_GenerateKeyPair
+    from pkcs11_structs import CK_MECHANISM
+    pkcs11.C_GenerateKeyPair.argtypes = [
+        ctypes.c_ulong,                         # CK_SESSION_HANDLE
+        ctypes.POINTER(CK_MECHANISM),           # CK_MECHANISM_PTR
+        ctypes.POINTER(CK_ATTRIBUTE), ctypes.c_ulong,  # public template
+        ctypes.POINTER(CK_ATTRIBUTE), ctypes.c_ulong,  # private template
+        ctypes.POINTER(ctypes.c_ulong),         # CK_OBJECT_HANDLE_PTR (public)
+        ctypes.POINTER(ctypes.c_ulong),         # CK_OBJECT_HANDLE_PTR (private)
+    ]
+    pkcs11.C_GenerateKeyPair.restype = ctypes.c_ulong

--- a/pkcs11_structs.py
+++ b/pkcs11_structs.py
@@ -24,6 +24,19 @@ CKK_EC_EDWARDS = 0x00000040
 CKK_EC_MONTGOMERY = 0x00000041
 CKK_GOSTR3410 = 0x00000030
 
+# Дополнительные атрибуты и механизмы
+CKA_TOKEN = 0x00000001
+CKA_PRIVATE = 0x00000002
+CKA_MODULUS_BITS = 0x00000121
+CKA_PUBLIC_EXPONENT = 0x00000122
+CKA_EC_PARAMS = 0x00000180
+CKA_GOSTR3410_PARAMS = 0x00000250
+
+CKM_RSA_PKCS_KEY_PAIR_GEN = 0x00000000
+CKM_EC_KEY_PAIR_GEN = 0x00001040
+CKM_EC_EDWARDS_KEY_PAIR_GEN = 0x00001055
+CKM_GOSTR3410_KEY_PAIR_GEN = 0x00001200
+
 CKF_SERIAL_SESSION = 1 << 1  # 0x00000002
 CKF_RW_SESSION = 1 << 2  # 0x00000004
 
@@ -91,4 +104,13 @@ class CK_ATTRIBUTE(ctypes.Structure):
         ('type', ctypes.c_ulong),
         ('pValue', ctypes.c_void_p),
         ('ulValueLen', ctypes.c_ulong),
+    ]
+
+
+class CK_MECHANISM(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [
+        ('mechanism', ctypes.c_ulong),
+        ('pParameter', ctypes.c_void_p),
+        ('ulParameterLen', ctypes.c_ulong),
     ]

--- a/tests/test_generate_keypair.py
+++ b/tests/test_generate_keypair.py
@@ -1,0 +1,61 @@
+import ctypes
+from types import SimpleNamespace
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import commands
+import pkcs11
+import pkcs11_structs as structs
+
+
+def make_pkcs11_mock(captured):
+    pkcs11_mock = SimpleNamespace()
+
+    def open_session(slot, flags, app, notify, session_ptr):
+        session_ptr._obj.value = 1
+        return 0
+    pkcs11_mock.C_OpenSession = open_session
+    pkcs11_mock.C_Login = lambda *args, **kwargs: 0
+    pkcs11_mock.C_CloseSession = lambda session: 0
+
+    def generate_key_pair(session, mech_ptr, pub_tpl, pub_count, priv_tpl, priv_count, pub_h_ptr, priv_h_ptr):
+        mech = ctypes.cast(mech_ptr, ctypes.POINTER(structs.CK_MECHANISM)).contents
+        captured['mechanism'] = mech.mechanism
+        arr_type = structs.CK_ATTRIBUTE * pub_count
+        arr = ctypes.cast(pub_tpl, ctypes.POINTER(arr_type)).contents
+        for attr in arr:
+            if attr.type == structs.CKA_MODULUS_BITS:
+                val = ctypes.cast(attr.pValue, ctypes.POINTER(ctypes.c_ulong)).contents.value
+                captured['modulus_bits'] = val
+        return 0
+    pkcs11_mock.C_GenerateKeyPair = generate_key_pair
+
+    return pkcs11_mock
+
+
+def setup(monkeypatch, captured):
+    pkcs11_mock = make_pkcs11_mock(captured)
+    monkeypatch.setattr(pkcs11, 'load_pkcs11_lib', lambda: pkcs11_mock)
+    monkeypatch.setattr(pkcs11, 'initialize_library', lambda x: None)
+    monkeypatch.setattr(pkcs11, 'finalize_library', lambda x: None)
+    monkeypatch.setattr(commands, 'define_pkcs11_functions', lambda x: None)
+
+
+def test_generate_rsa2048(monkeypatch):
+    captured = {}
+    setup(monkeypatch, captured)
+
+    commands.generate_key_pair(slot_id=1, pin='1111', algorithm='rsa2048')
+
+    assert captured['mechanism'] == structs.CKM_RSA_PKCS_KEY_PAIR_GEN
+    assert captured['modulus_bits'] == 2048
+
+
+def test_generate_ed25519(monkeypatch):
+    captured = {}
+    setup(monkeypatch, captured)
+
+    commands.generate_key_pair(slot_id=1, pin='1111', algorithm='ed25519')
+
+    assert captured['mechanism'] == structs.CKM_EC_EDWARDS_KEY_PAIR_GEN
+


### PR DESCRIPTION
## Summary
- support key pair generation through `C_GenerateKeyPair`
- extend PKCS#11 structures/constants
- expose new `generate_key_pair` command and CLI option
- document generation in README
- test RSA 2048 and Ed25519 generation logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692a438c0483298b23184071c752df