### PR TITLE
Add PKCS#11 key pair deletion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # wallet-tool
 Example app to control the wallet. Supported commands include listing slots,
-resetting the token and generating key pairs via PKCS#11.
+resetting the token, generating and deleting key pairs via PKCS#11.
 
 ```
 python main.py --generate-key ed25519 --pin 0000
+python main.py --delete-key 1 --pin 0000
 ```

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from commands import (
     list_wallets,
     list_objects,
     generate_key_pair,
+    delete_key_pair,
 )
 
 # Для Windows: переключаем потоки в UTF-8, чтобы не падать на кириллице
@@ -32,6 +33,8 @@ def main():
                         help='Показать список объектов в кошельке')
     parser.add_argument('--generate-key', choices=['secp256', 'ed25519', 'gost', 'rsa1024', 'rsa2048'],
                         help='Сгенерировать ключевую пару указанного типа')
+    parser.add_argument('--delete-key', type=int,
+                        help='Удалить ключевую пару по номеру')
     parser.add_argument('--slot-id', type=int, default=0,
                         help='Идентификатор слота для выполнения команды (по умолчанию 0)')
     parser.add_argument('--pin', type=str, default=None,
@@ -51,6 +54,8 @@ def main():
         list_objects(args.slot_id, args.pin)
     elif args.generate_key:
         generate_key_pair(args.slot_id, args.pin, args.generate_key)
+    elif args.delete_key is not None:
+        delete_key_pair(args.slot_id, args.pin, args.delete_key)
     else:
         parser.print_help()
 

--- a/pkcs11_definitions.py
+++ b/pkcs11_definitions.py
@@ -59,3 +59,10 @@ def define_pkcs11_functions(pkcs11):
         ctypes.POINTER(ctypes.c_ulong),         # CK_OBJECT_HANDLE_PTR (private)
     ]
     pkcs11.C_GenerateKeyPair.restype = ctypes.c_ulong
+
+    # C_DestroyObject
+    pkcs11.C_DestroyObject.argtypes = [
+        ctypes.c_ulong,  # CK_SESSION_HANDLE
+        ctypes.c_ulong,  # CK_OBJECT_HANDLE
+    ]
+    pkcs11.C_DestroyObject.restype = ctypes.c_ulong

--- a/tests/test_delete_keypair.py
+++ b/tests/test_delete_keypair.py
@@ -1,0 +1,88 @@
+import ctypes
+from types import SimpleNamespace
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import commands
+import pkcs11
+import pkcs11_structs as structs
+
+
+def setup_mock(monkeypatch, with_private):
+    pkcs11_mock = SimpleNamespace()
+
+    def open_session(slot, flags, app, notify, session_ptr):
+        session_ptr._obj.value = 1
+        return 0
+    pkcs11_mock.C_OpenSession = open_session
+    pkcs11_mock.C_Login = lambda *args, **kwargs: 0
+    pkcs11_mock.C_FindObjectsFinal = lambda session: 0
+    pkcs11_mock.C_CloseSession = lambda session: 0
+
+    current_class = None
+
+    def find_objects_init(session_handle, template_ptr, count):
+        arr_type = structs.CK_ATTRIBUTE * count
+        arr = ctypes.cast(template_ptr, ctypes.POINTER(arr_type)).contents
+        val_ptr = ctypes.cast(arr[0].pValue, ctypes.POINTER(ctypes.c_ulong))
+        nonlocal current_class
+        current_class = val_ptr.contents.value
+        return 0
+    pkcs11_mock.C_FindObjectsInit = find_objects_init
+
+    def find_objects(session, obj_ptr, max_obj, count_ptr):
+        if current_class == structs.CKO_PUBLIC_KEY and not hasattr(find_objects, 'pub_done'):
+            obj_ptr._obj.value = 10
+            count_ptr._obj.value = 1
+            find_objects.pub_done = True
+        elif with_private and current_class == structs.CKO_PRIVATE_KEY and not hasattr(find_objects, 'priv_done'):
+            obj_ptr._obj.value = 11
+            count_ptr._obj.value = 1
+            find_objects.priv_done = True
+        else:
+            count_ptr._obj.value = 0
+        return 0
+    pkcs11_mock.C_FindObjects = find_objects
+
+    def get_attribute_value(session, obj, attr_ptr, count):
+        attr = ctypes.cast(attr_ptr, ctypes.POINTER(structs.CK_ATTRIBUTE)).contents
+        if not attr.pValue:
+            if attr.type == structs.CKA_ID:
+                attr.ulValueLen = 1
+            else:
+                attr.ulValueLen = 0
+            return 0
+        if attr.type == structs.CKA_ID:
+            b = (ctypes.c_ubyte * 1)(1)
+            ctypes.memmove(attr.pValue, b, 1)
+        return 0
+    pkcs11_mock.C_GetAttributeValue = get_attribute_value
+
+    destroyed = []
+
+    def destroy_object(session, handle):
+        destroyed.append(handle)
+        return 0
+    pkcs11_mock.C_DestroyObject = destroy_object
+
+    monkeypatch.setattr(pkcs11, 'load_pkcs11_lib', lambda: pkcs11_mock)
+    monkeypatch.setattr(pkcs11, 'initialize_library', lambda x: None)
+    monkeypatch.setattr(pkcs11, 'finalize_library', lambda x: None)
+    monkeypatch.setattr(commands, 'define_pkcs11_functions', lambda x: None)
+
+    return destroyed
+
+
+def test_delete_pair_with_private(monkeypatch):
+    destroyed = setup_mock(monkeypatch, True)
+
+    commands.delete_key_pair(slot_id=1, pin='0000', number=1)
+
+    assert set(destroyed) == {10, 11}
+
+
+def test_delete_pair_only_public(monkeypatch):
+    destroyed = setup_mock(monkeypatch, False)
+
+    commands.delete_key_pair(slot_id=1, pin=None, number=1)
+
+    assert destroyed == [10]


### PR DESCRIPTION
## Summary
- allow removing keys from the token using `--delete-key`
- implement `delete_key_pair` command with PKCS#11 `C_DestroyObject`
- register `C_DestroyObject` in PKCS#11 function definitions
- document new command
- test deletion logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692ca5afcc8329baac5a006fe4905f