### PR TITLE
Add parameters for key generation attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Example app to control the wallet. Supported commands include listing slots,
 resetting the token, generating and deleting key pairs via PKCS#11.
 
 ```
-python main.py --generate-key ed25519 --pin 0000
+python main.py --generate-key ed25519 --pin 0000 --key-id myid --key-label mylabel
 python main.py --delete-key 1 --pin 0000
 ```

--- a/main.py
+++ b/main.py
@@ -33,6 +33,10 @@ def main():
                         help='Показать список объектов в кошельке')
     parser.add_argument('--generate-key', choices=['secp256', 'ed25519', 'gost', 'rsa1024', 'rsa2048'],
                         help='Сгенерировать ключевую пару указанного типа')
+    parser.add_argument('--key-id', type=str, default='',
+                        help='CKA_ID для создаваемой ключевой пары')
+    parser.add_argument('--key-label', type=str, default='',
+                        help='CKA_LABEL для создаваемой ключевой пары')
     parser.add_argument('--delete-key', type=int,
                         help='Удалить ключевую пару по номеру')
     parser.add_argument('--slot-id', type=int, default=0,
@@ -53,7 +57,13 @@ def main():
     elif args.list_objects:
         list_objects(args.slot_id, args.pin)
     elif args.generate_key:
-        generate_key_pair(args.slot_id, args.pin, args.generate_key)
+        generate_key_pair(
+            args.slot_id,
+            args.pin,
+            args.generate_key,
+            cka_id=args.key_id,
+            cka_label=args.key_label,
+        )
     elif args.delete_key is not None:
         delete_key_pair(args.slot_id, args.pin, args.delete_key)
     else:


### PR DESCRIPTION
## Summary
- allow setting `CKA_ID` and `CKA_LABEL` when generating key pairs
- ensure PKCS11 templates set `CKA_TOKEN` and `CKA_PRIVATE` correctly for each key
- expose new CLI options `--key-id` and `--key-label`
- document usage in README
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698cd0a6348329a81a56df192d0b9d