### PR TITLE
Enforce key id and label for key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # wallet-tool
 Example app to control the wallet. Supported commands include listing slots,
 resetting the token, generating and deleting key pairs via PKCS#11.
+When generating a key pair both ``--key-id`` and ``--key-label`` must be
+specified.
 
 ```
 python main.py --generate-key ed25519 --pin 0000 --key-id myid --key-label mylabel

--- a/commands.py
+++ b/commands.py
@@ -327,6 +327,11 @@ def generate_key_pair(pkcs11, slot_id, pin, algorithm, cka_id="", cka_label=""):
         print(f'C_OpenSession вернула ошибку: 0x{rv:08X}')
         return
 
+    if not cka_id or not cka_label:
+        print('Необходимо указать key-id и key-label для генерации ключа', file=sys.stderr)
+        pkcs11.C_CloseSession(session)
+        return
+
     if not pin:
         print('Необходимо указать PIN-код для генерации ключа', file=sys.stderr)
         pkcs11.C_CloseSession(session)

--- a/main.py
+++ b/main.py
@@ -57,13 +57,16 @@ def main():
     elif args.list_objects:
         list_objects(args.slot_id, args.pin)
     elif args.generate_key:
-        generate_key_pair(
-            args.slot_id,
-            args.pin,
-            args.generate_key,
-            cka_id=args.key_id,
-            cka_label=args.key_label,
-        )
+        if not args.key_id or not args.key_label:
+            print('Необходимо указать --key-id и --key-label для генерации ключа', file=sys.stderr)
+        else:
+            generate_key_pair(
+                args.slot_id,
+                args.pin,
+                args.generate_key,
+                cka_id=args.key_id,
+                cka_label=args.key_label,
+            )
     elif args.delete_key is not None:
         delete_key_pair(args.slot_id, args.pin, args.delete_key)
     else:

--- a/tests/test_generate_keypair.py
+++ b/tests/test_generate_keypair.py
@@ -92,3 +92,20 @@ def test_generate_ed25519(monkeypatch):
     assert captured['priv_%d' % structs.CKA_LABEL] == b'x'
 
 
+def test_generate_missing_id_label(monkeypatch, capsys):
+    captured = {}
+    setup(monkeypatch, captured)
+
+    commands.generate_key_pair(
+        slot_id=1,
+        pin='1111',
+        algorithm='ed25519',
+        cka_id='',
+        cka_label='',
+    )
+
+    assert captured == {}
+    err = capsys.readouterr().err
+    assert 'key-id' in err and 'key-label' in err
+
+


### PR DESCRIPTION
## Summary
- require `key-id` and `key-label` when generating keys
- show error in CLI when missing args
- document the new requirement
- test that generation fails without id/label

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68699325f22083299ba4286cdfa73562