### PR TITLE
Require PIN for key deletion

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -498,14 +498,17 @@ def delete_key_pair(pkcs11, slot_id, pin, number):
         print(f'C_OpenSession вернула ошибку: 0x{rv:08X}')
         return
 
-    logged_in = False
-    if pin:
-        rv = pkcs11.C_Login(session, 1, pin.encode('utf-8'), len(pin))
-        if rv != 0:
-            print(f'C_Login вернула ошибку: 0x{rv:08X}')
-            pkcs11.C_CloseSession(session)
-            return
-        logged_in = True
+    if not pin:
+        print('Необходимо указать PIN-код для удаления ключей', file=sys.stderr)
+        pkcs11.C_CloseSession(session)
+        return
+
+    rv = pkcs11.C_Login(session, 1, pin.encode('utf-8'), len(pin))
+    if rv != 0:
+        print(f'C_Login вернула ошибку: 0x{rv:08X}')
+        pkcs11.C_CloseSession(session)
+        return
+    logged_in = True
 
     def search_objects(obj_class):
         class_val = ctypes.c_ulong(obj_class)

--- a/tests/test_delete_keypair.py
+++ b/tests/test_delete_keypair.py
@@ -80,9 +80,11 @@ def test_delete_pair_with_private(monkeypatch):
     assert set(destroyed) == {10, 11}
 
 
-def test_delete_pair_only_public(monkeypatch):
+def test_delete_pair_requires_pin(monkeypatch, capsys):
     destroyed = setup_mock(monkeypatch, False)
 
     commands.delete_key_pair(slot_id=1, pin=None, number=1)
 
-    assert destroyed == [10]
+    err = capsys.readouterr().err
+    assert 'PIN-код' in err
+    assert destroyed == []


### PR DESCRIPTION
## Summary
- add a PIN check in `delete_key_pair`
- update tests to expect the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686997356f788329a905b14bec78eab7