### PR TITLE
Fix GOST key generation attributes

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -467,6 +467,11 @@ def generate_key_pair(pkcs11, slot_id, pin, algorithm, cka_id="", cka_label=""):
             pValue=ctypes.cast(hash_oid, ctypes.c_void_p),
             ulValueLen=10,
         ))
+        priv_attrs.append(CK_ATTRIBUTE(
+            type=CKA_GOSTR3410_PARAMS,
+            pValue=ctypes.cast(oid, ctypes.c_void_p),
+            ulValueLen=11,
+        ))
     else:
         print('Неверный тип ключа')
         pkcs11.C_CloseSession(session)

--- a/tests/test_generate_keypair.py
+++ b/tests/test_generate_keypair.py
@@ -126,6 +126,7 @@ def test_generate_gost_params(monkeypatch):
     assert captured['mechanism'] == structs.CKM_GOSTR3410_KEY_PAIR_GEN
     assert 'pub_%d' % structs.CKA_GOSTR3410_PARAMS in captured
     assert 'pub_%d' % structs.CKA_GOSTR3411_PARAMS in captured
+    assert 'priv_%d' % structs.CKA_GOSTR3410_PARAMS in captured
     assert 'priv_%d' % structs.CKA_GOSTR3411_PARAMS in captured
 
 


### PR DESCRIPTION
## Summary
- ensure private key template receives GOST params
- update GOST generation test for new attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a6058b1c8329a47b008a16735905